### PR TITLE
Fillspill: Passflow satisfies min/max parameters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ numpy = "*"
 pandas = "*"
 pydantic = "*"
 rtc-tools = "^2.7.0a4"
-rtc-tools-interface = "0.10.*, 0.10.0a1"
+rtc-tools-interface = ">0.9.*"
 
 [tool.poetry.scripts]
 rtc-tools-reservoir-template = "rtctools_simulation.cli.reservoir:create_reservoir_template"

--- a/rtctools_simulation/reservoir/model.py
+++ b/rtctools_simulation/reservoir/model.py
@@ -393,10 +393,12 @@ class ReservoirModel(Model):
                 parameters["Reservoir_Qmin"] - q_spill,
                 min(q_out_forh_target - q_spill, parameters["Reservoir_Qmax"]),
             )
-        elif current_h == parameters["Reservoir_Htarget"]:
-            self.apply_passflow()
-            return
         else:
+            # NOTE: In this case we do not consider spill, as h < Spillway_H
+            # The passflow case is also handled here, we do not apply the
+            # existing passflow scheme as that scheme sets Q_out directly.
+            # For consistency we handle it here and set Q_turbine.
+            # In this way we also consider min and max discharges.
             calc_q = max(
                 parameters["Reservoir_Qmin"], min(parameters["Reservoir_Qmax"], q_out_forh_target)
             )


### PR DESCRIPTION
Within fillspill, passflow is triggered when the current water level is equal to the target level. However
1. the passflow scheme does not consider the min/max parameters supplied to the fillspill scheme,
2. It also does not consider rain/evaporation.
3. the passflow scheme sets Q_Out directly (and sets Q_Spill and Q_turbine to zero) which is inconsistent with the rest of the scheme which considers Q_Out = Q_spill + Q_turbine.

Thus we use calc_q also for the passflow part of the fillspill scheme. When flows are within the min/max range results are unchanged other than we set Q_turbine instead of Q_out. when inflow is outside of the min/max range, Q_turbine flow obeys the range. (an example of this case is seen in this issue https://issuetracker.deltares.nl/browse/RTCTOOLS-1428).

Note: we already check if the current water level is above the spill level, so we are sure that Q_spill is zero. 

Dependencies are also updated for rtc-tools-interface to resolve issues with installing a prerelease. 